### PR TITLE
add #[warn(missing_doc)] and #[warn(missing_debug_implementation)]

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use {parse, Ip, Network, ParseError};
+use {grammar, Ip, Network, ParseError};
 
 /// Encompasses the nameserver configuration
 ///
@@ -66,6 +66,6 @@ impl Config {
         }
     }
     pub fn parse<T: AsRef<[u8]>>(buf: T) -> Result<Config, ParseError> {
-        parse(buf.as_ref())
+        grammar::parse(buf.as_ref())
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -7,27 +7,36 @@ quick_error!{
     /// Error while parsing resolv.conf file
     #[derive(Debug)]
     pub enum ParseError {
+        /// Error that may be returned when the string to parse contains invalid UTF-8 sequences
         InvalidUtf8(line: usize, err: Utf8Error) {
             display("bad unicode at line {}: {}", line, err)
             cause(err)
         }
+        /// Error returned a value for a given directive is invalid.
+        /// This can also happen when the value is missing, if the directive requires a value.
         InvalidValue(line: usize) {
             display("directive at line {} is improperly formatted \
                 or contains invalid value", line)
         }
+        /// Error returned when a value for a given option is invalid.
+        /// This can also happen when the value is missing, if the option requires a value.
         InvalidOptionValue(line: usize) {
             display("directive options at line {} contains invalid \
                 value of some option", line)
         }
+        /// Error returned when a invalid option is found.
         InvalidOption(line: usize) {
             display("option at line {} is not recognized", line)
         }
+        /// Error returned when a invalid directive is found.
         InvalidDirective(line: usize) {
             display("directive at line {} is not recognized", line)
         }
+        /// Error returned when a value cannot be parsed an an IP address.
         InvalidIp(line: usize, err: AddrParseError) {
             display("directive at line {} contains invalid IP: {}", line, err)
         }
+        /// Error returned when there is extra data at the end of a line.
         ExtraData(line: usize) {
             display("extra data at the end of the line {}", line)
         }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -102,7 +102,7 @@ fn ip_v6_netw(val: &str) -> Result<Network, AddrParseError> {
     }
 }
 
-pub fn parse(bytes: &[u8]) -> Result<Config, ParseError> {
+pub(crate) fn parse(bytes: &[u8]) -> Result<Config, ParseError> {
     use self::ParseError::*;
     let mut cfg = Config::new();
     'lines: for (lineno, line) in bytes.split(|&x| x == b'\n').enumerate() {

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -3,11 +3,12 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
-/// A network, that is an IP address and the mask
+/// A network, that is an IP address and a mask
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Network {
-    // Address netmask
+    /// Represent an IPv4 network address
     V4(Ipv4Addr, Ipv4Addr),
+    /// Represent an IPv6 network address
     V6(Ipv6Addr, Ipv6Addr),
 }
 
@@ -83,6 +84,7 @@ impl Ip {
     }
 }
 
+/// An error which can be returned when parsing an IP address.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddrParseError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,92 @@
 //! The crate simply parses `/etc/resolv.conf` file and creates a config object
 //!
+//! # Examples
 //!
+//! ## Parsing a config from a string
+//! ```rust
+//! extern crate resolv_conf;
+//!
+//! use std::net::{Ipv4Addr, Ipv6Addr};
+//! use resolv_conf::{Ip, Config, Network};
+//!
+//! fn main() {
+//!     let config_str = "
+//! options ndots:8 timeout:8 attempts:8
+//!
+//! domain example.com
+//! search example.com sub.example.com
+//!
+//! nameserver 2001:4860:4860::8888
+//! nameserver 2001:4860:4860::8844
+//! nameserver 8.8.8.8
+//! nameserver 8.8.4.4
+//!
+//! options rotate
+//! options inet6 no-tld-query
+//!
+//! sortlist 130.155.160.0/255.255.240.0 130.155.0.0";
+//!
+//!     // Parse the config.
+//!     let parsed_config = Config::parse(&config_str).expect("Failed to parse config");
+//!
+//!     // We can build configs manually as well, either directly or with Config::new()
+//!     let expected_config = Config {
+//!         nameservers: vec![
+//!             Ip::V6(Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888), None),
+//!             Ip::V6(Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8844), None),
+//!             Ip::V4(Ipv4Addr::new(8, 8, 8, 8)),
+//!             Ip::V4(Ipv4Addr::new(8, 8, 4, 4)),
+//!         ],
+//!         search: vec![String::from("example.com"), String::from("sub.example.com")],
+//!         sortlist: vec![
+//!             Network::V4(Ipv4Addr::new(130, 155, 160, 0), Ipv4Addr::new(255, 255, 240, 0)),
+//!             Network::V4(Ipv4Addr::new(130, 155, 0, 0), Ipv4Addr::new(255, 255, 0, 0)),
+//!         ],
+//!         debug: false,
+//!         ndots: 8,
+//!         timeout: 8,
+//!         attempts: 8,
+//!         rotate: true,
+//!         no_check_names: false,
+//!         inet6: true,
+//!         ip6_bytestring: false,
+//!         ip6_dotint: false,
+//!         edns0: false,
+//!         single_request: false,
+//!         single_request_reopen: false,
+//!         no_tld_query: true,
+//!         use_vc: false,
+//!     };
+//!
+//!     // We can compare configurations, since resolv_conf::Config implements Eq
+//!     assert_eq!(parsed_config, expected_config);
+//! }
+//! ```
+//!
+//! ## Parsing a file
+//!
+//! ```rust
+//! use std::io::Read;
+//! use std::fs::File;
+//!
+//! extern crate resolv_conf;
+//!
+//! fn main() {
+//!     // Read the file
+//!     let mut buf = Vec::with_capacity(4096);
+//!     let mut f = File::open("/etc/resolv.conf").unwrap();
+//!     f.read_to_end(&mut buf).unwrap();
+//!
+//!     // Parse the buffer
+//!     let cfg = resolv_conf::Config::parse(&buf).unwrap();
+//!
+//!     // Print the config
+//!     println!("---- Parsed /etc/resolv.conf -----\n{:#?}\n", cfg);
+//! }
+//! ```
+
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
 
 #[macro_use]
 extern crate quick_error;
@@ -9,7 +95,6 @@ mod grammar;
 mod ip;
 mod config;
 
-
-pub use grammar::{parse, ParseError};
+pub use grammar::ParseError;
 pub use ip::{AddrParseError, Ip, Network};
 pub use config::Config;


### PR DESCRIPTION
The doc is mostly code examples, adapted from the tests and from the example.