### PR TITLE
Implement Display for Config, Network and ScopedIp

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::iter::{IntoIterator, Iterator};
 use std::slice::Iter;
 use {grammar, Network, ParseError, ScopedIp};
@@ -278,6 +279,89 @@ impl Config {
             };
             return None;
         })
+    }
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        for nameserver in self.nameservers.iter() {
+            writeln!(fmt, "nameserver {}", nameserver)?;
+        }
+
+        if self.last_search != LastSearch::Domain {
+            if let Some(ref domain) = self.domain {
+                writeln!(fmt, "domain {}", domain)?;
+            }
+        }
+
+        if let Some(ref search) = self.search {
+            if !search.is_empty() {
+                write!(fmt, "search")?;
+                for suffix in search.iter() {
+                    write!(fmt, " {}", suffix)?;
+                }
+                writeln!(fmt)?;
+            }
+        }
+
+        if self.last_search == LastSearch::Domain {
+            if let Some(ref domain) = self.domain {
+                writeln!(fmt, "domain {}", domain)?;
+            }
+        }
+
+        if !self.sortlist.is_empty() {
+            write!(fmt, "sortlist")?;
+            for network in self.sortlist.iter() {
+                write!(fmt, " {}", network)?;
+            }
+            writeln!(fmt)?;
+        }
+
+        if self.debug {
+            writeln!(fmt, "options debug")?;
+        }
+        if self.ndots != 1 {
+            writeln!(fmt, "options ndots:{}", self.ndots)?;
+        }
+        if self.timeout != 5 {
+            writeln!(fmt, "options timeout:{}", self.timeout)?;
+        }
+        if self.attempts != 2 {
+            writeln!(fmt, "options attempts:{}", self.attempts)?;
+        }
+        if self.rotate {
+            writeln!(fmt, "options rotate")?;
+        }
+        if self.no_check_names {
+            writeln!(fmt, "options no-check-names")?;
+        }
+        if self.inet6 {
+            writeln!(fmt, "options inet6")?;
+        }
+        if self.ip6_bytestring {
+            writeln!(fmt, "options ip6-bytestring")?;
+        }
+        if self.ip6_dotint {
+            writeln!(fmt, "options ip6-dotint")?;
+        }
+        if self.edns0 {
+            writeln!(fmt, "options edns0")?;
+        }
+        if self.single_request {
+            writeln!(fmt, "options single-request")?;
+        }
+        if self.single_request_reopen {
+            writeln!(fmt, "options single-request-reopen")?;
+        }
+        if self.no_tld_query {
+            writeln!(fmt, "options no-tld-query")?;
+        }
+        if self.use_vc {
+            writeln!(fmt, "options use-vc")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -12,6 +12,15 @@ pub enum Network {
     V6(Ipv6Addr, Ipv6Addr),
 }
 
+impl fmt::Display for Network {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Network::V4(address, mask) => write!(fmt, "{}/{}", address, mask),
+            Network::V6(address, mask) => write!(fmt, "{}/{}", address, mask),
+        }
+    }
+}
+
 /// Represent an IP address. This type is similar to `std::net::IpAddr` but it supports IPv6 scope
 /// identifiers.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,6 +99,16 @@ impl FromStr for ScopedIp {
                 Ok(ScopedIp::V6(ip, None))
             },
             Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl fmt::Display for ScopedIp {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ScopedIp::V4(ref address) => address.fmt(fmt),
+            ScopedIp::V6(ref address, None) => address.fmt(fmt),
+            ScopedIp::V6(ref address, Some(ref scope)) => write!(fmt, "{}%{}", address, scope),
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -298,3 +298,81 @@ fn test_get_system_domain() {
     let config = resolv_conf::Config::new();
     assert_eq!(Some("lan".into()), config.get_system_domain());
 }
+
+#[test]
+fn test_default_display() {
+    let original_config = resolv_conf::Config::new();
+    let output = original_config.to_string();
+    let restored_config = resolv_conf::Config::parse(&output).unwrap();
+
+    assert_eq!(original_config, restored_config);
+}
+
+#[test]
+fn test_non_default_display() {
+    let mut original_config = resolv_conf::Config::new();
+
+    original_config.nameservers = vec![
+        ip("192.168.0.94"),
+        ip("fe80::0123:4567:89ab:cdef"),
+        ip("fe80::0123:4567:89ab:cdef%zone"),
+    ];
+
+    original_config.sortlist = vec![
+        Network::V4(
+            "192.168.1.94".parse().unwrap(),
+            "255.255.252.0".parse().unwrap(),
+        ),
+        Network::V6("fe80::0123".parse().unwrap(), "fe80::cdef".parse().unwrap()),
+    ];
+
+    original_config.set_domain("my.domain".to_owned());
+
+    original_config.set_search(
+        vec!["my.domain", "alt.domain"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+    );
+
+    original_config.debug = true;
+    original_config.ndots = 4;
+    original_config.timeout = 20;
+    original_config.attempts = 5;
+    original_config.rotate = true;
+    original_config.no_check_names = true;
+    original_config.inet6 = true;
+    original_config.ip6_bytestring = true;
+    original_config.ip6_dotint = true;
+    original_config.edns0 = true;
+    original_config.single_request = true;
+    original_config.single_request_reopen = true;
+    original_config.no_tld_query = true;
+    original_config.use_vc = true;
+
+    let output = original_config.to_string();
+    println!("Output:\n\n{}", output);
+    let restored_config = resolv_conf::Config::parse(&output).unwrap();
+
+    assert_eq!(original_config, restored_config);
+}
+
+#[test]
+fn test_display_preservers_last_search() {
+    let mut original_config = resolv_conf::Config::new();
+
+    original_config.set_search(
+        vec!["my.domain", "alt.domain"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+    );
+
+    original_config.set_domain("my.domain".to_owned());
+
+    let output = original_config.to_string();
+    println!("Output:\n\n{}", output);
+    let restored_config = resolv_conf::Config::parse(&output).unwrap();
+
+    assert_eq!(original_config, restored_config);
+}


### PR DESCRIPTION
The `Display` implementation for `Config` allows it to print a `resolv.conf` file using the in-memory configuration.