### PR TITLE
Redox OS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 quick-error = "1.0.0"
-hostname = { version = "0.1.3", optional = true }
+hostname = { version = "0.1.5", optional = true }
 
 [features]
 system = ["hostname"]


### PR DESCRIPTION
This updates `hostname` version to one with support for Redox OS.

If you could do a release after merging this, that'd be awesome! We're trying to upstream a crate that depends on this one :)