### PR TITLE
add no-strict feature to ignore InvalidDirectives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ hostname = { version = "0.1.5", optional = true }
 
 [features]
 system = ["hostname"]
+no-strict = []
 
 [lib]
 name = "resolv_conf"

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -29,6 +29,7 @@ quick_error!{
             display("option at line {} is not recognized", line)
         }
         /// Error returned when a invalid directive is found.
+        #[cfg(not(feature="no-strict"))]
         InvalidDirective(line: usize) {
             display("directive at line {} is not recognized", line)
         }
@@ -222,7 +223,12 @@ pub(crate) fn parse(bytes: &[u8]) -> Result<Config, ParseError> {
                     }
                 }
             }
+            #[cfg(not(feature="no-strict"))]
             _ => return Err(InvalidDirective(lineno)),
+
+            #[cfg(feature="no-strict")]
+            _ => /* ignore invalid directives when no-strict */ (),
+
         }
     }
     Ok(cfg)


### PR DESCRIPTION
Fix for #17

It's sometimes desireable to ignore invalid directives so that the
supplied configuration can still be used. This change adds a feature
flag `no-strict` that when enabled, does not return an
`Err(InvalidDirective(_))` when a directive isn't valid. Instead, it
skips over it, allowing the configuration to be used.