### PR TITLE
cargo: update to latest hostname version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 quick-error = "1.0.0"
-hostname = { version = "0.1.5", optional = true }
+hostname = { version = "^0.3", optional = true }
 
 [features]
 system = ["hostname"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,9 +4,6 @@ use std::slice::Iter;
 use {grammar, Network, ParseError, ScopedIp};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-#[cfg(feature = "system")]
-use hostname::get_hostname;
-
 const NAMESERVER_LIMIT:usize = 3;
 const SEARCH_LIMIT:usize = 6;
 
@@ -278,14 +275,19 @@ impl Config {
             return self.domain.clone();
         }
 
-        get_hostname().and_then(|s| {
+        let hostname = match ::hostname::get().ok() {
+            Some(name) => name.into_string().ok(),
+            None => return None,
+        };
+
+        hostname.and_then(|s| {
             if let Some(pos) = s.find('.') {
                 let hn = s[pos + 1..].to_string();
                 if !hn.is_empty() {
                     return Some(hn)
                 }
             };
-            return None;
+            None
         })
     }
 }


### PR DESCRIPTION
This updates the optional `hostname` dependency to the latest
version (0.3.0).

Signed-off-by: Luca BRUNO <luca.bruno@coreos.com>