### PR TITLE
Implement new glibc options no-reload and trust-ad

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,10 @@ pub struct Config {
     pub no_tld_query: bool,
     /// Force using TCP for DNS resolution
     pub use_vc: bool,
+    /// Disable the automatic reloading of a changed configuration file
+    pub no_reload: bool,
+    /// Optionally send the AD (authenticated data) bit in queries
+    pub trust_ad: bool,
     /// The order in which databases should be searched during a lookup
     /// **(openbsd-only)**
     pub lookup: Vec<Lookup>,
@@ -150,6 +154,8 @@ impl Config {
             single_request_reopen: false,
             no_tld_query: false,
             use_vc: false,
+            no_reload: false,
+            trust_ad: false,
             lookup: Vec::new(),
             family: Vec::new(),
         }
@@ -369,6 +375,12 @@ impl fmt::Display for Config {
         }
         if self.use_vc {
             writeln!(fmt, "options use-vc")?;
+        }
+        if self.no_reload {
+            writeln!(fmt, "options no-reload")?;
+        }
+        if self.trust_ad {
+            writeln!(fmt, "options trust-ad")?;
         }
 
         Ok(())

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -198,6 +198,8 @@ pub(crate) fn parse(bytes: &[u8]) -> Result<Config, ParseError> {
                         ("edns0", _) => cfg.edns0 = true,
                         ("single-request", _) => cfg.single_request = true,
                         ("single-request-reopen", _) => cfg.single_request_reopen = true,
+                        ("no-reload", _) => cfg.no_reload = true,
+                        ("trust-ad", _) => cfg.trust_ad =true,
                         ("no-tld-query", _) => cfg.no_tld_query = true,
                         ("use-vc", _) => cfg.use_vc = true,
                         _ => return Err(InvalidOption(lineno)),

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -199,7 +199,7 @@ pub(crate) fn parse(bytes: &[u8]) -> Result<Config, ParseError> {
                         ("single-request", _) => cfg.single_request = true,
                         ("single-request-reopen", _) => cfg.single_request_reopen = true,
                         ("no-reload", _) => cfg.no_reload = true,
-                        ("trust-ad", _) => cfg.trust_ad =true,
+                        ("trust-ad", _) => cfg.trust_ad = true,
                         ("no-tld-query", _) => cfg.no_tld_query = true,
                         ("use-vc", _) => cfg.use_vc = true,
                         _ => return Err(InvalidOption(lineno)),


### PR DESCRIPTION
Implements new options added in `glibc 2.26` and `glibc 2.31`

Closes #21