### PR TITLE
Add repository link to Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["dns", "unix", "conf", "resolv"]
 categories = ["parser-implementations"]
 homepage = "http://github.com/tailhook/resolv-conf"
 documentation = "https://docs.rs/resolv-conf/"
+repository = "http://github.com/tailhook/resolv-conf"
 version = "0.6.3"
 authors = ["paul@colomiets.name"]
 
@@ -22,4 +23,3 @@ system = ["hostname"]
 [lib]
 name = "resolv_conf"
 path = "src/lib.rs"
-


### PR DESCRIPTION
I was just looking into resolv-conf due to https://github.com/bluejekyll/trust-dns/issues/1131#issuecomment-717904658 and was confused for a little bit when I didn't find a Repository link on crates.io.