### PR TITLE
Change to allow for easy linking with jemalloc for downstream crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,7 +489,6 @@ impl Config {
 
         #[cfg(not(all(target_os = "linux", target_feature = "crt-static")))]
         {
-            #[link(name = "c")]
             /*unsafe*/
             extern "C" {
                 fn gethostname(hostname: *mut u8, size: usize) -> i32;


### PR DESCRIPTION
Linking to libc directly was affecting symbol resolution order when using libraries such as jemalloc, causing libc symbols to be preferred even when linked with jemalloc. This patch removes the explicit `#[link(name = "c")]`. This was practically seen in [compiling continuwuity 0.5.0-rc.7 on nixos](https://github.com/NixOS/nixpkgs/pull/440963#issuecomment-3283887096) where continuwuity would exit with a `free(): invalid pointer` error when compiled with jemalloc, but using resolv-conf with this patch worked perfectly. Removing this line does not seem to have any practical effects in my (limited) testing.

An alternate fix would be to call the libc crate explicitly, but I think this solution may be more elegant, if it does not cause any other issues.